### PR TITLE
Add extended Doctrine AnnotationReader

### DIFF
--- a/Annotation/AnnotationReader.php
+++ b/Annotation/AnnotationReader.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
 
 namespace SuperBrave\GdprBundle\Annotation;
 

--- a/Annotation/AnnotationReader.php
+++ b/Annotation/AnnotationReader.php
@@ -25,7 +25,8 @@ class AnnotationReader extends DoctrineAnnotationReader
     /**
      * Returns a list of annotation instances for the properties having the specified annotation.
      *
-     * @param ReflectionClass $class
+     * @param ReflectionClass $class          The ReflectionClass of the class from which
+     *                                        the class annotations should be read
      * @param string          $annotationName The FQCN of the annotation class
      *
      * @return object[]

--- a/Annotation/AnnotationReader.php
+++ b/Annotation/AnnotationReader.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SuperBrave\GdprBundle\Annotation;
+
+use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
+use ReflectionClass;
+
+/**
+ * AnnotationReader.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class AnnotationReader extends DoctrineAnnotationReader
+{
+    /**
+     * Returns a list of annotation instances for the properties having the specified annotation.
+     *
+     * @param ReflectionClass $class
+     * @param string          $annotationName The FQCN of the annotation class
+     *
+     * @return object[]
+     */
+    public function getPropertiesWithAnnotation(ReflectionClass $class, $annotationName)
+    {
+        $annotatedProperties = array();
+
+        $properties = $class->getProperties();
+        foreach ($properties as $property) {
+            $annotation = $this->getPropertyAnnotation($property, $annotationName);
+            if ($annotation instanceof $annotationName) {
+                $annotatedProperties[$property->getName()] = $annotation;
+            }
+        }
+
+        return $annotatedProperties;
+    }
+}

--- a/Annotation/Export.php
+++ b/Annotation/Export.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
 
 namespace SuperBrave\GdprBundle\Annotation;
 

--- a/Annotation/Export.php
+++ b/Annotation/Export.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SuperBrave\GdprBundle\Annotation;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Annotation to flag an entity field to be exported
+ * to conform with the GDPR right of portability.
+ *
+ * @Annotation
+ * @Annotation\Target({"PROPERTY"})
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class Export
+{
+    /**
+     * Use given name instead of column name in the exported data.
+     *
+     * @var string
+     */
+    public $fieldName;
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,6 @@
 services:
-#    super_brave_gdpr.example:
-#        class: SuperBrave\GdprBundle\Example
-#        arguments: ["@service_id", "plain_value", "%parameter%"]
+    _defaults:
+        public: false
+
+    super_brave_gdpr.annotation.reader:
+        class: SuperBrave\GdprBundle\Annotation\AnnotationReader

--- a/Tests/AnnotatedMock.php
+++ b/Tests/AnnotatedMock.php
@@ -59,6 +59,13 @@ class AnnotatedMock
     private $quux;
 
     /**
+     * The property that is not annotated with the Export annotation.
+     *
+     * @var null
+     */
+    private $notAnnotatedProperty = null;
+
+    /**
      * Constructs a new AnnotatedMock instance.
      *
      * @param AnnotatedMock|null $annotatedMock An AnnotatedMock instance
@@ -106,5 +113,15 @@ class AnnotatedMock
     public function getQuux()
     {
         return $this->quux;
+    }
+
+    /**
+     * Returns the value of the notAnnotatedProperty property.
+     *
+     * @return null
+     */
+    public function getNotAnnotatedProperty()
+    {
+        return $this->notAnnotatedProperty;
     }
 }

--- a/Tests/AnnotatedMock.php
+++ b/Tests/AnnotatedMock.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SuperBrave\GdprBundle\Tests;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use SuperBrave\GdprBundle\Annotation as GDPR;
+
+/**
+ * AnnotatedMock.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class AnnotatedMock
+{
+    /**
+     * @GDPR\Export()
+     *
+     * @var string
+     */
+    private $foo = 'bar';
+
+    /**
+     * @GDPR\Export()
+     *
+     * @var int
+     */
+    private $baz = 1;
+
+    /**
+     * @GDPR\Export()
+     *
+     * @var array
+     */
+    private $qux = array();
+
+    /**
+     * @GDPR\Export()
+     *
+     * @var ArrayCollection
+     */
+    private $quux;
+
+    /**
+     * Constructs a new AnnotatedMock instance.
+     *
+     * @param AnnotatedMock|null $annotatedMock
+     */
+    public function __construct(AnnotatedMock $annotatedMock = null)
+    {
+        $this->quux = new ArrayCollection(array($annotatedMock));
+    }
+
+    /**
+     * @return string
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBaz()
+    {
+        return $this->baz;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQux()
+    {
+        return $this->qux;
+    }
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getQuux()
+    {
+        return $this->quux;
+    }
+}

--- a/Tests/AnnotatedMock.php
+++ b/Tests/AnnotatedMock.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
 
 namespace SuperBrave\GdprBundle\Tests;
 
@@ -6,13 +16,15 @@ use Doctrine\Common\Collections\ArrayCollection;
 use SuperBrave\GdprBundle\Annotation as GDPR;
 
 /**
- * AnnotatedMock.
+ * Class used to test the @see GDPR\AnnotationReader.
  *
  * @author Niels Nijens <nn@superbrave.nl>
  */
 class AnnotatedMock
 {
     /**
+     * The foo property.
+     *
      * @GDPR\Export()
      *
      * @var string
@@ -20,6 +32,8 @@ class AnnotatedMock
     private $foo = 'bar';
 
     /**
+     * The baz property.
+     *
      * @GDPR\Export()
      *
      * @var int
@@ -27,6 +41,8 @@ class AnnotatedMock
     private $baz = 1;
 
     /**
+     * The qux property.
+     *
      * @GDPR\Export()
      *
      * @var array
@@ -34,6 +50,8 @@ class AnnotatedMock
     private $qux = array();
 
     /**
+     * The quux property.
+     *
      * @GDPR\Export()
      *
      * @var ArrayCollection
@@ -43,7 +61,7 @@ class AnnotatedMock
     /**
      * Constructs a new AnnotatedMock instance.
      *
-     * @param AnnotatedMock|null $annotatedMock
+     * @param AnnotatedMock|null $annotatedMock An AnnotatedMock instance
      */
     public function __construct(AnnotatedMock $annotatedMock = null)
     {
@@ -51,6 +69,8 @@ class AnnotatedMock
     }
 
     /**
+     * Returns the value of the foo property.
+     *
      * @return string
      */
     public function getFoo()
@@ -59,6 +79,8 @@ class AnnotatedMock
     }
 
     /**
+     * Returns the value of the baz property.
+     *
      * @return int
      */
     public function getBaz()
@@ -67,6 +89,8 @@ class AnnotatedMock
     }
 
     /**
+     * Returns the value of the qux property.
+     *
      * @return array
      */
     public function getQux()
@@ -75,6 +99,8 @@ class AnnotatedMock
     }
 
     /**
+     * Returns the value of the quux property.
+     *
      * @return ArrayCollection
      */
     public function getQuux()

--- a/Tests/Annotation/AnnotationReaderTest.php
+++ b/Tests/Annotation/AnnotationReaderTest.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
 
 namespace SuperBrave\GdprBundle\Tests\Annotation;
 
@@ -16,6 +26,8 @@ use SuperBrave\GdprBundle\Tests\AnnotatedMock;
 class AnnotationReaderTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * The AnnotationReader instance being tested.
+     *
      * @var AnnotationReader
      */
     private $annotationReader;
@@ -27,7 +39,9 @@ class AnnotationReaderTest extends PHPUnit_Framework_TestCase
     {
         $this->annotationReader = new AnnotationReader();
 
-        // Ensure the Export annotation class is autoloaded.
+        // Ensure the Export annotation class is autoloaded, because the \Doctrine\Common\Annotations\DocParser
+        // used in the AnnotationReader does not use the existing classloaders.
+        // Only the AnnotationRegistry classloader.
         class_exists(Export::class);
     }
 

--- a/Tests/Annotation/AnnotationReaderTest.php
+++ b/Tests/Annotation/AnnotationReaderTest.php
@@ -2,6 +2,7 @@
 
 namespace SuperBrave\GdprBundle\Tests\Annotation;
 
+use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 use SuperBrave\GdprBundle\Annotation\AnnotationReader;
 use SuperBrave\GdprBundle\Annotation\Export;
@@ -12,7 +13,7 @@ use SuperBrave\GdprBundle\Tests\AnnotatedMock;
  *
  * @author Niels Nijens <nn@superbrave.nl>
  */
-class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
+class AnnotationReaderTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var AnnotationReader

--- a/Tests/Annotation/AnnotationReaderTest.php
+++ b/Tests/Annotation/AnnotationReaderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SuperBrave\GdprBundle\Tests\Annotation;
+
+use ReflectionClass;
+use SuperBrave\GdprBundle\Annotation\AnnotationReader;
+use SuperBrave\GdprBundle\Annotation\Export;
+use SuperBrave\GdprBundle\Tests\AnnotatedMock;
+
+/**
+ * AnnotationReaderTest.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AnnotationReader
+     */
+    private $annotationReader;
+
+    /**
+     * Creates a new AnnotationReader instance for testing.
+     */
+    public function setUp()
+    {
+        $this->annotationReader = new AnnotationReader();
+
+        // Ensure the Export annotation class is autoloaded.
+        class_exists(Export::class);
+    }
+
+    /**
+     * Tests if AnnotationReader::getPropertiesWithAnnotation returns a keyed array with the annotation instances.
+     */
+    public function testGetPropertiesWithAnnotation()
+    {
+        $result = $this->annotationReader->getPropertiesWithAnnotation(
+            new ReflectionClass(AnnotatedMock::class),
+            Export::class
+        );
+
+        $this->assertInternalType('array', $result);
+        $this->assertCount(4, $result);
+        $this->assertSame(
+            array('foo', 'baz', 'qux', 'quux'),
+            array_keys($result)
+        );
+        $this->assertInstanceOf(Export::class, current($result));
+    }
+}

--- a/Tests/Annotation/AnnotationReaderTest.php
+++ b/Tests/Annotation/AnnotationReaderTest.php
@@ -34,6 +34,8 @@ class AnnotationReaderTest extends PHPUnit_Framework_TestCase
 
     /**
      * Creates a new AnnotationReader instance for testing.
+     *
+     * @return void
      */
     public function setUp()
     {
@@ -47,6 +49,8 @@ class AnnotationReaderTest extends PHPUnit_Framework_TestCase
 
     /**
      * Tests if AnnotationReader::getPropertiesWithAnnotation returns a keyed array with the annotation instances.
+     *
+     * @return void
      */
     public function testGetPropertiesWithAnnotation()
     {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
   ],
   "licence"    : "MIT License",
   "require"    : {
-    "php"            : ">=5.6.0",
+    "php": ">=5.6.0",
+    "doctrine/annotations": "^1.4",
     "symfony/framework-bundle": "^3.0.0"
   },
   "require-dev": {
@@ -23,6 +24,7 @@
     "bin-dir"    : "bin",
     "platform"   : {
       "php": "5.6.0"
-    }
+    },
+    "sort-packages": true
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,133 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fd8d3957f91f76a953a82926f441417",
+    "content-hash": "aa0e48cf5a1c0ad9315d82620b61e7d6",
     "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-02-24T16:22:25+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
         {
             "name": "paragonie/random_compat",
             "version": "v2.0.12",


### PR DESCRIPTION
This PR adds an extended Doctrine AnnotationReader to be able to return all annotation instances of all properties tagged with the specified annotation.