### PR TITLE
Add AnnotationNormalizer

### DIFF
--- a/Annotation/Export.php
+++ b/Annotation/Export.php
@@ -26,9 +26,9 @@ use Doctrine\Common\Annotations\Annotation;
 class Export
 {
     /**
-     * Use given name instead of column name in the exported data.
+     * The alias is used as name/key for the exported value instead of property name.
      *
      * @var string
      */
-    public $fieldName;
+    public $alias;
 }

--- a/Serializer/Normalizer/AnnotationNormalizer.php
+++ b/Serializer/Normalizer/AnnotationNormalizer.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
+
+namespace SuperBrave\GdprBundle\Serializer\Normalizer;
+
+use ReflectionClass;
+use ReflectionProperty;
+use SuperBrave\GdprBundle\Annotation\AnnotationReader;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
+
+/**
+ * Normalizes object data based on the specified property annotation.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class AnnotationNormalizer implements NormalizerInterface, SerializerAwareInterface
+{
+    use SerializerAwareTrait;
+
+    /**
+     * The AnnotationReader instance.
+     *
+     * @var AnnotationReader
+     */
+    private $annotationReader;
+
+    /**
+     * The FQCN of the annotation class.
+     *
+     * @var string
+     */
+    private $annotationName;
+
+    /**
+     * The property accessor instance.
+     *
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    /**
+     * Constructs a new AnnotationNormalizer instance.
+     *
+     * @param AnnotationReader          $annotationReader The AnnotationReader instance
+     * @param string                    $annotationName   The FQCN of the annotation class
+     * @param PropertyAccessorInterface $propertyAccessor The property accessor instance
+     */
+    public function __construct(
+        AnnotationReader $annotationReader,
+        $annotationName,
+        PropertyAccessorInterface $propertyAccessor
+    ) {
+        $this->annotationReader = $annotationReader;
+        $this->annotationName = $annotationName;
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        if (is_object($data) === false) {
+            return false;
+        }
+
+        $propertyAnnotations = $this->annotationReader->getPropertiesWithAnnotation(
+            new ReflectionClass($data),
+            $this->annotationName
+        );
+
+        return count($propertyAnnotations) > 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizedData = array();
+        $propertyAnnotations = $this->annotationReader->getPropertiesWithAnnotation(
+            new ReflectionClass($object),
+            $this->annotationName
+        );
+
+        foreach ($propertyAnnotations as $propertyName => $propertyAnnotation) {
+            $propertyValue = $this->getPropertyValue($object, $propertyName);
+            if (property_exists($propertyAnnotation, 'fieldName') && isset($propertyAnnotation->fieldName)) {
+                $propertyName = $propertyAnnotation->fieldName;
+            }
+
+            $normalizedData[$propertyName] = $propertyValue;
+        }
+
+        return $normalizedData;
+    }
+
+    /**
+     * Returns the value of specified property through the getter of the object.
+     *
+     * @param object $object       The object being normalized
+     * @param string $propertyName The property name where the value gotten from
+     *
+     * @return mixed
+     */
+    private function getPropertyValue($object, $propertyName)
+    {
+        $propertyData = $this->propertyAccessor->getValue($object, $propertyName);
+
+        return $propertyData;
+    }
+}

--- a/Serializer/Normalizer/AnnotationNormalizer.php
+++ b/Serializer/Normalizer/AnnotationNormalizer.php
@@ -98,8 +98,8 @@ class AnnotationNormalizer implements NormalizerInterface, SerializerAwareInterf
 
         foreach ($propertyAnnotations as $propertyName => $propertyAnnotation) {
             $propertyValue = $this->getPropertyValue($object, $propertyName);
-            if (property_exists($propertyAnnotation, 'fieldName') && isset($propertyAnnotation->fieldName)) {
-                $propertyName = $propertyAnnotation->fieldName;
+            if (property_exists($propertyAnnotation, 'alias') && isset($propertyAnnotation->alias)) {
+                $propertyName = $propertyAnnotation->alias;
             }
 
             $normalizedData[$propertyName] = $propertyValue;

--- a/Serializer/Normalizer/AnnotationNormalizer.php
+++ b/Serializer/Normalizer/AnnotationNormalizer.php
@@ -18,18 +18,14 @@ use SuperBrave\GdprBundle\Annotation\AnnotationReader;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Serializer\SerializerAwareInterface;
-use Symfony\Component\Serializer\SerializerAwareTrait;
 
 /**
  * Normalizes object data based on the specified property annotation.
  *
  * @author Niels Nijens <nn@superbrave.nl>
  */
-class AnnotationNormalizer implements NormalizerInterface, SerializerAwareInterface
+class AnnotationNormalizer implements NormalizerInterface
 {
-    use SerializerAwareTrait;
-
     /**
      * The AnnotationReader instance.
      *

--- a/Serializer/Normalizer/AnnotationNormalizer.php
+++ b/Serializer/Normalizer/AnnotationNormalizer.php
@@ -65,7 +65,12 @@ class AnnotationNormalizer implements NormalizerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Checks whether the given class is supported for normalization by this normalizer.
+     *
+     * @param mixed  $data   Data to normalize
+     * @param string $format The format being (de-)serialized from or into
+     *
+     * @return bool
      */
     public function supportsNormalization($data, $format = null)
     {
@@ -82,7 +87,13 @@ class AnnotationNormalizer implements NormalizerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Normalizes an object into a set of arrays/scalars.
+     *
+     * @param object $object  Object to normalize
+     * @param string $format  Format the normalization result will be encoded as
+     * @param array  $context Context options for the normalizer
+     *
+     * @return array|string|int|float|bool
      */
     public function normalize($object, $format = null, array $context = array())
     {

--- a/Serializer/Normalizer/AnnotationNormalizer.php
+++ b/Serializer/Normalizer/AnnotationNormalizer.php
@@ -118,7 +118,14 @@ class AnnotationNormalizer implements NormalizerInterface, SerializerAwareInterf
      */
     private function getPropertyValue($object, $propertyName)
     {
-        $propertyData = $this->propertyAccessor->getValue($object, $propertyName);
+        try {
+            $propertyData = $this->propertyAccessor->getValue($object, $propertyName);
+        } catch (NoSuchPropertyException $exception) {
+            $reflectionProperty = new ReflectionProperty($object, $propertyName);
+            $reflectionProperty->setAccessible(true);
+
+            $propertyData = $reflectionProperty->getValue($object);
+        }
 
         return $propertyData;
     }

--- a/Tests/AnnotatedMock.php
+++ b/Tests/AnnotatedMock.php
@@ -59,6 +59,15 @@ class AnnotatedMock
     private $quux;
 
     /**
+     * The property that is annotated with the Export annotation, but without getter method.
+     *
+     * @GDPR\Export()
+     *
+     * @var bool
+     */
+    private $annotatedPropertyWithoutMethod = true;
+
+    /**
      * The property that is not annotated with the Export annotation.
      *
      * @var null

--- a/Tests/AnnotatedMock.php
+++ b/Tests/AnnotatedMock.php
@@ -52,7 +52,7 @@ class AnnotatedMock
     /**
      * The quux property.
      *
-     * @GDPR\Export(fieldName="quuxs")
+     * @GDPR\Export(alias="quuxs")
      *
      * @var ArrayCollection
      */

--- a/Tests/AnnotatedMock.php
+++ b/Tests/AnnotatedMock.php
@@ -52,7 +52,7 @@ class AnnotatedMock
     /**
      * The quux property.
      *
-     * @GDPR\Export()
+     * @GDPR\Export(fieldName="quuxs")
      *
      * @var ArrayCollection
      */
@@ -72,7 +72,12 @@ class AnnotatedMock
      */
     public function __construct(AnnotatedMock $annotatedMock = null)
     {
-        $this->quux = new ArrayCollection(array($annotatedMock));
+        $elements = array();
+        if ($annotatedMock instanceof AnnotatedMock) {
+            $elements[] = $annotatedMock;
+        }
+
+        $this->quux = new ArrayCollection($elements);
     }
 
     /**

--- a/Tests/Annotation/AnnotationReaderTest.php
+++ b/Tests/Annotation/AnnotationReaderTest.php
@@ -60,9 +60,9 @@ class AnnotationReaderTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertInternalType('array', $result);
-        $this->assertCount(4, $result);
+        $this->assertCount(5, $result);
         $this->assertSame(
-            array('foo', 'baz', 'qux', 'quux'),
+            array('foo', 'baz', 'qux', 'quux', 'annotatedPropertyWithoutMethod'),
             array_keys($result)
         );
         $this->assertInstanceOf(Export::class, current($result));

--- a/Tests/Resources/xml/annotation_normalizer_result.xml
+++ b/Tests/Resources/xml/annotation_normalizer_result.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<mock><foo>bar</foo><baz>1</baz><qux/><quuxs><item key="0"><foo>bar</foo><baz>1</baz><qux/><quuxs/></item></quuxs></mock>

--- a/Tests/Resources/xml/annotation_normalizer_result.xml
+++ b/Tests/Resources/xml/annotation_normalizer_result.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0"?>
-<mock><foo>bar</foo><baz>1</baz><qux/><quuxs><item key="0"><foo>bar</foo><baz>1</baz><qux/><quuxs/></item></quuxs></mock>
+<mock><foo>bar</foo><baz>1</baz><qux/><quuxs><item key="0"><foo>bar</foo><baz>1</baz><qux/><quuxs/><annotatedPropertyWithoutMethod>1</annotatedPropertyWithoutMethod></item></quuxs><annotatedPropertyWithoutMethod>1</annotatedPropertyWithoutMethod></mock>

--- a/Tests/Serializer/Normalizer/AnnotationNormalizerTest.php
+++ b/Tests/Serializer/Normalizer/AnnotationNormalizerTest.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
+
+namespace SuperBrave\GdprBundle\Tests\Serializer\Normalizer;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use ReflectionClass;
+use SuperBrave\GdprBundle\Annotation\AnnotationReader;
+use SuperBrave\GdprBundle\Annotation\Export;
+use SuperBrave\GdprBundle\Serializer\Normalizer\AnnotationNormalizer;
+use SuperBrave\GdprBundle\Tests\AnnotatedMock;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * AnnotationNormalizerTest.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class AnnotationNormalizerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * The AnnotationNormalizer instance being tested.
+     *
+     * @var AnnotationNormalizer
+     */
+    private $normalizer;
+
+    /**
+     * The mock AnnotationReader instance.
+     *
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $annotationReaderMock;
+
+    /**
+     * The mock property accessor instance.
+     *
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $propertyAccessorMock;
+
+    /**
+     * Creates a new AnnotationNormalizer instance for testing.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->annotationReaderMock = $this->getMockBuilder(AnnotationReader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->propertyAccessorMock = $this->getMockBuilder(PropertyAccessorInterface::class)
+            ->getMock();
+
+        $this->normalizer = new AnnotationNormalizer(
+            $this->annotationReaderMock,
+            Export::class,
+            $this->propertyAccessorMock
+        );
+    }
+
+    /**
+     * Tests if constructing a new AnnotationNormalizer sets the instance properties.
+     *
+     * @return void
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame($this->annotationReaderMock, 'annotationReader', $this->normalizer);
+        $this->assertAttributeSame(Export::class, 'annotationName', $this->normalizer);
+        $this->assertAttributeSame($this->propertyAccessorMock, 'propertyAccessor', $this->normalizer);
+    }
+
+    /**
+     * Tests if AnnotationNormalizer::supportsNormalization returns false
+     * when the data is not an object.
+     *
+     * @return void
+     */
+    public function testSupportsNormalizationReturnsFalseWhenDataIsNotAnObject()
+    {
+        $this->annotationReaderMock->expects($this->never())
+            ->method('getPropertiesWithAnnotation');
+
+        $this->assertFalse($this->normalizer->supportsNormalization('no object'));
+    }
+
+    /**
+     * Tests if AnnotationNormalizer::supportsNormalization returns false
+     * when the AnnotationReader does not return annotation instances.
+     *
+     * @return void
+     */
+    public function testSupportsNormalizationReturnsFalseWhenAnnotationReaderDoesNotReturnAnnotations()
+    {
+        $this->annotationReaderMock->expects($this->once())
+            ->method('getPropertiesWithAnnotation')
+            ->with(
+                $this->isInstanceOf(ReflectionClass::class),
+                Export::class
+            )
+            ->willReturn(array());
+
+        $this->assertFalse($this->normalizer->supportsNormalization(new AnnotatedMock()));
+    }
+
+    /**
+     * Tests if AnnotationNormalizer::supportsNormalization returns true
+     * when the AnnotationReader returns annotation instances.
+     *
+     * @return void
+     */
+    public function testSupportsNormalizationReturnsFalseWhenAnnotationReaderReturnsAnnotations()
+    {
+        $this->annotationReaderMock->expects($this->once())
+            ->method('getPropertiesWithAnnotation')
+            ->with(
+                $this->isInstanceOf(ReflectionClass::class),
+                Export::class
+            )
+            ->willReturn(array(
+                'foo' => new Export(),
+            ));
+
+        $this->assertTrue($this->normalizer->supportsNormalization(new AnnotatedMock()));
+    }
+
+    /**
+     * Tests if AnnotationNormalizer::normalize returns the expected array of a AnnotatedMock instance.
+     *
+     * @return void
+     */
+    public function testNormalize()
+    {
+        $annotationReader = new AnnotationReader();
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        $normalizer = new AnnotationNormalizer($annotationReader, Export::class, $propertyAccessor);
+
+        $annotatedMock = new AnnotatedMock();
+
+        $this->assertEquals(
+            array(
+                'foo' => 'bar',
+                'baz' => 1,
+                'qux' => array(),
+                'quuxs' => new ArrayCollection(),
+            ),
+            $normalizer->normalize($annotatedMock)
+        );
+    }
+
+    /**
+     * Tests if AnnotationNormalizer::normalize returns the expected normalized data
+     * for serialization through the Serializer.
+     *
+     * @return void
+     */
+    public function testNormalizeThroughSerializer()
+    {
+        $annotationReader = new AnnotationReader();
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        $normalizer = new AnnotationNormalizer($annotationReader, Export::class, $propertyAccessor);
+        $encoder = new XmlEncoder('mock');
+
+        $serializer = new Serializer(
+            array($normalizer),
+            array($encoder)
+        );
+
+        $data = new AnnotatedMock(new AnnotatedMock());
+
+        $this->assertStringEqualsFile(
+            __DIR__.'/../../Resources/xml/annotation_normalizer_result.xml',
+            $serializer->serialize($data, 'xml')
+        );
+    }
+}

--- a/Tests/Serializer/Normalizer/AnnotationNormalizerTest.php
+++ b/Tests/Serializer/Normalizer/AnnotationNormalizerTest.php
@@ -158,6 +158,7 @@ class AnnotationNormalizerTest extends \PHPUnit_Framework_TestCase
                 'baz' => 1,
                 'qux' => array(),
                 'quuxs' => new ArrayCollection(),
+                'annotatedPropertyWithoutMethod' => true,
             ),
             $normalizer->normalize($annotatedMock)
         );

--- a/Tests/Serializer/Normalizer/AnnotationNormalizerTest.php
+++ b/Tests/Serializer/Normalizer/AnnotationNormalizerTest.php
@@ -123,7 +123,7 @@ class AnnotationNormalizerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testSupportsNormalizationReturnsFalseWhenAnnotationReaderReturnsAnnotations()
+    public function testSupportsNormalizationReturnsTrueWhenAnnotationReaderReturnsAnnotations()
     {
         $this->annotationReaderMock->expects($this->once())
             ->method('getPropertiesWithAnnotation')

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "symfony/serializer": "^3.4"
   },
   "require-dev": {
-    "phpunit/phpunit"          : "^5.6",
+    "doctrine/collections": "^1.4",
+    "phpunit/phpunit": "^5.6",
     "squizlabs/php_codesniffer": "^3.2"
   },
   "autoload"   : {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
   "require"    : {
     "php": ">=5.6.0",
     "doctrine/annotations": "^1.4",
-    "symfony/framework-bundle": "^3.0.0"
+    "symfony/framework-bundle": "^3.0.0",
+    "symfony/property-access": "^3.4",
+    "symfony/serializer": "^3.4"
   },
   "require-dev": {
     "phpunit/phpunit"          : "^5.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e68863c1903223c841cb17df6ffb0e28",
+    "content-hash": "572a8d0a4818caa474f3f64639b39250",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1557,6 +1557,73 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "doctrine/collections",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-01-03T10:49:41+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa0e48cf5a1c0ad9315d82620b61e7d6",
+    "content-hash": "e68863c1903223c841cb17df6ffb0e28",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1101,6 +1101,63 @@
             "time": "2018-04-06T15:19:48+00:00"
         },
         {
+            "name": "symfony/inflector",
+            "version": "v3.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/inflector.git",
+                "reference": "217fa0f0e8fce417bd225e4195b12c56e87273a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/inflector/zipball/217fa0f0e8fce417bd225e4195b12c56e87273a8",
+                "reference": "217fa0f0e8fce417bd225e4195b12c56e87273a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Inflector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Inflector Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string",
+                "symfony",
+                "words"
+            ],
+            "time": "2018-01-03T17:14:19+00:00"
+        },
+        {
             "name": "symfony/polyfill-apcu",
             "version": "v1.7.0",
             "source": {
@@ -1275,6 +1332,74 @@
             "time": "2018-01-30T19:27:44+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v3.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "a6e8c778b220dfd5cd5f5dcb09f87ee232dd608a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/a6e8c778b220dfd5cd5f5dcb09f87ee232dd608a",
+                "reference": "a6e8c778b220dfd5cd5f5dcb09f87ee232dd608a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/inflector": "~3.1|~4.0",
+                "symfony/polyfill-php70": "~1.0"
+            },
+            "require-dev": {
+                "symfony/cache": "~3.1|~4.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "To cache access methods."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PropertyAccess Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property path",
+                "reflection"
+            ],
+            "time": "2018-01-03T07:37:34+00:00"
+        },
+        {
             "name": "symfony/routing",
             "version": "v3.4.8",
             "source": {
@@ -1351,6 +1476,84 @@
                 "url"
             ],
             "time": "2018-04-04T13:22:16+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v3.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "d4dc1551da627273230fe16511f4bb4844c02399"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/d4dc1551da627273230fe16511f4bb4844c02399",
+                "reference": "d4dc1551da627273230fe16511f4bb4844c02399",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "phpdocumentor/type-resolver": "<0.2.1",
+                "symfony/dependency-injection": "<3.2",
+                "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
+                "symfony/property-info": "<3.1",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/cache": "~3.1|~4.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.2|~4.0",
+                "symfony/http-foundation": "~2.8|~3.0|~4.0",
+                "symfony/property-access": "~2.8|~3.0|~4.0",
+                "symfony/property-info": "~3.1|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/http-foundation": "To use the DataUriNormalizer.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/property-info": "To deserialize relations.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Serializer Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-03-15T19:08:29+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This PR adds the AnnotationNormalizer for serializing objects based on an annotation with the Symfony Serializer component.