### PR TITLE
Add Exporter

### DIFF
--- a/Export/Exporter.php
+++ b/Export/Exporter.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
+
+namespace SuperBrave\GdprBundle\Export;
+
+use ReflectionClass;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Exporter.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class Exporter
+{
+    /**
+     * The Serializer instance.
+     *
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * The format an object is serialized to.
+     *
+     * @var string
+     */
+    private $format;
+
+    /**
+     * Constructs a new Export instance.
+     *
+     * @param SerializerInterface $serializer The Serializer instance
+     * @param string              $format     The format an object is serialized to
+     */
+    public function __construct(SerializerInterface $serializer, $format = 'xml')
+    {
+        $this->serializer = $serializer;
+        $this->format = $format;
+    }
+
+    /**
+     * Returns a serialized/exported version of the specified object.
+     *
+     * @param ObjectExportInterface $object     The object to be exported
+     * @param string|null           $objectName The name of the object used in the export (eg. the root node in XML)
+     *
+     * @return string
+     */
+    public function exportObject(ObjectExportInterface $object, $objectName = null)
+    {
+        $context = array(
+            'xml_root_node_name' => $objectName,
+        );
+
+        if (is_string($context['xml_root_node_name']) === false) {
+            $context['xml_root_node_name'] = (new ReflectionClass($object))->getShortName();
+        }
+
+        return $this->serializer->serialize($object, $this->format, $context);
+    }
+}

--- a/Export/ObjectExportInterface.php
+++ b/Export/ObjectExportInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
+
+namespace SuperBrave\GdprBundle\Export;
+
+/**
+ * The interface defining an object is exportable with @see Exporter.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+interface ObjectExportInterface
+{
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,3 +4,28 @@ services:
 
     super_brave_gdpr.annotation.reader:
         class: SuperBrave\GdprBundle\Annotation\AnnotationReader
+
+    super_brave_gdpr.exporter.serializer:
+        class: Symfony\Component\Serializer\Serializer
+        arguments:
+            - ["@super_brave_gdpr.exporter.serializer.normalizer.annotation"]
+            - [
+                "@super_brave_gdpr.exporter.serializer.encoder.xml",
+                "@super_brave_gdpr.exporter.serializer.encoder.json"
+              ]
+
+    super_brave_gdpr.exporter.serializer.normalizer.export_annotation:
+        class: SuperBrave\GdprBundle\Serializer\Normalizer\AnnotationNormalizer
+        arguments:
+            - "@super_brave_gdpr.annotation.reader"
+            - "SuperBrave\\GdprBundle\\Annotation\\Export"
+            - "@super_brave_gdpr.exporter.property_accessor"
+
+    super_brave_gdpr.exporter.serializer.encoder.xml:
+        class: Symfony\Component\Serializer\Encoder\XmlEncoder
+
+    super_brave_gdpr.exporter.serializer.encoder.json:
+        class: Symfony\Component\Serializer\Encoder\JsonEncoder
+
+    super_brave_gdpr.exporter.property_accessor:
+        class: Symfony\Component\PropertyAccess\PropertyAccessor

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,6 +5,13 @@ services:
     super_brave_gdpr.annotation.reader:
         class: SuperBrave\GdprBundle\Annotation\AnnotationReader
 
+    super_brave_gdpr.exporter:
+        class: SuperBrave\GdprBundle\Export\Exporter
+        arguments:
+            - "@super_brave_gdpr.exporter.serializer"
+            - "xml"
+        public: true
+
     super_brave_gdpr.exporter.serializer:
         class: Symfony\Component\Serializer\Serializer
         arguments:

--- a/Tests/AnnotatedMock.php
+++ b/Tests/AnnotatedMock.php
@@ -14,13 +14,14 @@ namespace SuperBrave\GdprBundle\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use SuperBrave\GdprBundle\Annotation as GDPR;
+use SuperBrave\GdprBundle\Export\ObjectExportInterface;
 
 /**
  * Class used to test the @see GDPR\AnnotationReader.
  *
  * @author Niels Nijens <nn@superbrave.nl>
  */
-class AnnotatedMock
+class AnnotatedMock implements ObjectExportInterface
 {
     /**
      * The foo property.

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
+
+namespace SuperBrave\GdprBundle\Tests\Export;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+use SuperBrave\GdprBundle\Export\Exporter;
+use SuperBrave\GdprBundle\Tests\AnnotatedMock;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * ExporterTest.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class ExporterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * The Exporter instance being tested.
+     *
+     * @var Exporter
+     */
+    private $exporter;
+
+    /**
+     * The mock serializer instance.
+     *
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializerMock;
+
+    /**
+     * Creates a new Exporter instance for testing.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->serializerMock = $this->getMockBuilder(SerializerInterface::class)
+            ->getMock();
+
+        $this->exporter = new Exporter($this->serializerMock, 'xml');
+    }
+
+    /**
+     * Tests if constructing a new Exporter instance sets the instance properties.
+     *
+     * @return void
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame($this->serializerMock, 'serializer', $this->exporter);
+        $this->assertAttributeSame('xml', 'format', $this->exporter);
+    }
+
+    /**
+     * Tests if Exporter::exportObject calls the serializer instance with the specified format
+     * and returns the result of the serializer.
+     *
+     * @return void
+     */
+    public function testExportObject()
+    {
+        $annotatedMock = new AnnotatedMock();
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with(
+                $annotatedMock,
+                'xml',
+                array('xml_root_node_name' => 'AnnotatedMock')
+            )
+            ->willReturn('<?xml version="1.0"?><AnnotatedMock/>');
+
+        $this->assertSame(
+            '<?xml version="1.0"?><AnnotatedMock/>',
+            $this->exporter->exportObject($annotatedMock)
+        );
+    }
+
+    /**
+     * Tests if Exporter::exportObject calls the serializer instance with the custom object name as context
+     * and returns the result of the serializer.
+     *
+     * @return void
+     */
+    public function testExportObjectWithObjectName()
+    {
+        $annotatedMock = new AnnotatedMock();
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with(
+                $annotatedMock,
+                'xml',
+                array('xml_root_node_name' => 'custom_name')
+            )
+            ->willReturn('<?xml version="1.0"?><custom_name/>');
+
+        $this->assertSame(
+            '<?xml version="1.0"?><custom_name/>',
+            $this->exporter->exportObject($annotatedMock, 'custom_name')
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the `Exporter` service/class which will be the main entrypoint to export an object based on the configured annotations within the class definition of the object.