### PR TITLE
Change normalizer and encoder services to tagged services for the Serializer

### DIFF
--- a/DependencyInjection/ObjectFactory.php
+++ b/DependencyInjection/ObjectFactory.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
+
+namespace SuperBrave\GdprBundle\DependencyInjection;
+
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * ObjectFactory.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class ObjectFactory
+{
+    /**
+     * Returns a new Serializer instance.
+     *
+     * @param NormalizerInterface[] $normalizers The collection of tagged normalizer services
+     * @param EncoderInterface[]    $encoders    The collection of tagged encoder services
+     *
+     * @return Serializer
+     */
+    public static function createSerializer($normalizers, $encoders)
+    {
+        return new Serializer(
+            iterator_to_array($normalizers),
+            iterator_to_array($encoders)
+        );
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,6 +14,7 @@ services:
 
     super_brave_gdpr.exporter.serializer:
         class: Symfony\Component\Serializer\Serializer
+        factory: ["SuperBrave\\GdprBundle\\DependencyInjection\\ObjectFactory", "createSerializer"]
         arguments:
             - !tagged "super_brave_gdpr.serializer.normalizer"
             - !tagged "super_brave_gdpr.serializer.encoder"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,11 +15,8 @@ services:
     super_brave_gdpr.exporter.serializer:
         class: Symfony\Component\Serializer\Serializer
         arguments:
-            - ["@super_brave_gdpr.exporter.serializer.normalizer.export_annotation"]
-            - [
-                "@super_brave_gdpr.exporter.serializer.encoder.xml",
-                "@super_brave_gdpr.exporter.serializer.encoder.json"
-              ]
+            - !tagged "super_brave_gdpr.serializer.normalizer"
+            - !tagged "super_brave_gdpr.serializer.encoder"
 
     super_brave_gdpr.exporter.serializer.normalizer.export_annotation:
         class: SuperBrave\GdprBundle\Serializer\Normalizer\AnnotationNormalizer
@@ -27,12 +24,18 @@ services:
             - "@super_brave_gdpr.annotation.reader"
             - "SuperBrave\\GdprBundle\\Annotation\\Export"
             - "@super_brave_gdpr.exporter.property_accessor"
+        tags:
+            - { name: "super_brave_gdpr.serializer.normalizer" }
 
     super_brave_gdpr.exporter.serializer.encoder.xml:
         class: Symfony\Component\Serializer\Encoder\XmlEncoder
+        tags:
+            - { name: "super_brave_gdpr.serializer.encoder" }
 
     super_brave_gdpr.exporter.serializer.encoder.json:
         class: Symfony\Component\Serializer\Encoder\JsonEncoder
+        tags:
+            - { name: "super_brave_gdpr.serializer.encoder" }
 
     super_brave_gdpr.exporter.property_accessor:
         class: Symfony\Component\PropertyAccess\PropertyAccessor


### PR DESCRIPTION
This PR changes the normalizer and encoder services for the Serializer services to tagged services. This way, you're able to add additional normalizers and encoders without changing the service definitions of the bundle.

The `ObjectFactory::createSerializer` is added to change the `RewindableGenerator` instance containing the normalizers or encoders back to an array, as the constructor arguments of `Serializer` are typehinted as `array`.

Makes use of the newly added Symfony 3.4 feature to configure tagged services:
https://symfony.com/doc/3.4/service_container/tags.html#reference-tagged-services