### PR TITLE
Add reading annotations from parent classes to AnnotationReader

### DIFF
--- a/Annotation/AnnotationReader.php
+++ b/Annotation/AnnotationReader.php
@@ -43,6 +43,14 @@ class AnnotationReader extends DoctrineAnnotationReader
             }
         }
 
+        $parentClass = $class->getParentClass();
+        if ($parentClass instanceof ReflectionClass) {
+            $annotatedProperties = array_merge(
+                $annotatedProperties,
+                $this->getPropertiesWithAnnotation($parentClass, $annotationName)
+            );
+        }
+
         return $annotatedProperties;
     }
 }

--- a/Tests/Annotation/AnnotationReaderTest.php
+++ b/Tests/Annotation/AnnotationReaderTest.php
@@ -17,6 +17,7 @@ use ReflectionClass;
 use SuperBrave\GdprBundle\Annotation\AnnotationReader;
 use SuperBrave\GdprBundle\Annotation\Export;
 use SuperBrave\GdprBundle\Tests\AnnotatedMock;
+use SuperBrave\GdprBundle\Tests\ExtendedAnnotedMock;
 
 /**
  * AnnotationReaderTest.
@@ -63,6 +64,28 @@ class AnnotationReaderTest extends PHPUnit_Framework_TestCase
         $this->assertCount(5, $result);
         $this->assertSame(
             array('foo', 'baz', 'qux', 'quux', 'annotatedPropertyWithoutMethod'),
+            array_keys($result)
+        );
+        $this->assertInstanceOf(Export::class, current($result));
+    }
+
+    /**
+     * Tests if AnnotationReader::getPropertiesWithAnnotation returns a keyed array with the annotation instances
+     * of both the class and the parent class.
+     *
+     * @return void
+     */
+    public function testGetPropertiesWithAnnotationForExtendedClass()
+    {
+        $result = $this->annotationReader->getPropertiesWithAnnotation(
+            new ReflectionClass(ExtendedAnnotedMock::class),
+            Export::class
+        );
+
+        $this->assertInternalType('array', $result);
+        $this->assertCount(6, $result);
+        $this->assertSame(
+            array('extendedProperty', 'foo', 'baz', 'qux', 'quux', 'annotatedPropertyWithoutMethod'),
             array_keys($result)
         );
         $this->assertInstanceOf(Export::class, current($result));

--- a/Tests/ExtendedAnnotedMock.php
+++ b/Tests/ExtendedAnnotedMock.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the GDPR bundle.
+ *
+ * @category  Bundle
+ * @package   Gdpr
+ * @author    SuperBrave <info@superbrave.nl>
+ * @copyright 2018 SuperBrave <info@superbrave.nl>
+ * @license   https://github.com/superbrave/gdpr-bundle/blob/master/LICENSE MIT
+ * @link      https://www.superbrave.nl/
+ */
+
+namespace SuperBrave\GdprBundle\Tests;
+
+use SuperBrave\GdprBundle\Annotation as GDPR;
+
+/**
+ * Class used to test the @see GDPR\AnnotationReader.
+ *
+ * @author Niels Nijens <nn@superbrave.nl>
+ */
+class ExtendedAnnotedMock extends AnnotatedMock
+{
+    /**
+     * The extended property.
+     *
+     * @GDPR\Export()
+     *
+     * @var bool
+     */
+    private $extendedProperty = true;
+
+    /**
+     * Returns the extended property.
+     *
+     * @return bool
+     */
+    public function getExtendedProperty()
+    {
+        return $this->extendedProperty;
+    }
+}


### PR DESCRIPTION
This PR adds reading annotations from parent classes to the `AnnotationReader`. This ensures that annotations from eg. Doctrine Proxy entities are still read on from the actual entity.