### PR TITLE
Add Travis CI configuration to only build on master and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ before_script:
 script:
   - bin/phpunit --log-junit build/logs/phpunit.xml
   - bin/phpcs --report-full --report-junit=build/logs/phpcs.xml
+
+branches:
+    only:
+        - master
+        - /^\d+\.\d+(\.\d+)?(-\S*)?$/


### PR DESCRIPTION
This PR adds Travis CI configuration to only build on (merge) commits to master and when tagging a release. It prevents adding excessive build failures on development branches or adding `[skip ci]` to commits.