### PR TITLE
 Add transforming of scalar values based on a value map to AnnotationNormalizer

### DIFF
--- a/Annotation/Export.php
+++ b/Annotation/Export.php
@@ -31,4 +31,11 @@ class Export
      * @var string
      */
     public $alias;
+
+    /**
+     * The value map used to change a value to a human-readable value.
+     *
+     * @var array
+     */
+    public $valueMap;
 }

--- a/Serializer/Normalizer/AnnotationNormalizer.php
+++ b/Serializer/Normalizer/AnnotationNormalizer.php
@@ -109,7 +109,7 @@ class AnnotationNormalizer implements NormalizerInterface
                 $propertyName = $propertyAnnotation->alias;
             }
 
-            $normalizedData[$propertyName] = $propertyValue;
+            $normalizedData[$propertyName] = $this->getMappedPropertyValue($propertyAnnotation, $propertyValue);
         }
 
         return $normalizedData;
@@ -135,5 +135,31 @@ class AnnotationNormalizer implements NormalizerInterface
         }
 
         return $propertyData;
+    }
+
+    /**
+     * Returns the mapped value of a property or the original value when no value map is configured on the annotation.
+     *
+     * @param object $annotation    The annotation instance
+     * @param mixed  $propertyValue The value of the property retrieved from the object
+     *
+     * @return mixed
+     */
+    private function getMappedPropertyValue($annotation, $propertyValue)
+    {
+        if (is_scalar($propertyValue) === false) {
+            return $propertyValue;
+        }
+
+        if (property_exists($annotation, 'valueMap') === false || isset($annotation->valueMap) === false) {
+            return $propertyValue;
+        }
+
+        $mappedPropertyValue = null;
+        if (isset($annotation->valueMap[$propertyValue])) {
+            $mappedPropertyValue = $annotation->valueMap[$propertyValue];
+        }
+
+        return $mappedPropertyValue;
     }
 }

--- a/Tests/AnnotatedMock.php
+++ b/Tests/AnnotatedMock.php
@@ -62,7 +62,12 @@ class AnnotatedMock implements ObjectExportInterface
     /**
      * The property that is annotated with the Export annotation, but without getter method.
      *
-     * @GDPR\Export()
+     * @GDPR\Export(
+     *     valueMap={
+     *         true = "Yes",
+     *         false = "No"
+     *     }
+     * )
      *
      * @var bool
      */

--- a/Tests/Resources/xml/annotation_normalizer_result.xml
+++ b/Tests/Resources/xml/annotation_normalizer_result.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0"?>
-<mock><foo>bar</foo><baz>1</baz><qux/><quuxs><item key="0"><foo>bar</foo><baz>1</baz><qux/><quuxs/><annotatedPropertyWithoutMethod>1</annotatedPropertyWithoutMethod></item></quuxs><annotatedPropertyWithoutMethod>1</annotatedPropertyWithoutMethod></mock>
+<mock><foo>bar</foo><baz>1</baz><qux/><quuxs><item key="0"><foo>bar</foo><baz>1</baz><qux/><quuxs/><annotatedPropertyWithoutMethod>Yes</annotatedPropertyWithoutMethod></item></quuxs><annotatedPropertyWithoutMethod>Yes</annotatedPropertyWithoutMethod></mock>

--- a/Tests/Serializer/Normalizer/AnnotationNormalizerTest.php
+++ b/Tests/Serializer/Normalizer/AnnotationNormalizerTest.php
@@ -158,7 +158,7 @@ class AnnotationNormalizerTest extends \PHPUnit_Framework_TestCase
                 'baz' => 1,
                 'qux' => array(),
                 'quuxs' => new ArrayCollection(),
-                'annotatedPropertyWithoutMethod' => true,
+                'annotatedPropertyWithoutMethod' => 'Yes',
             ),
             $normalizer->normalize($annotatedMock)
         );


### PR DESCRIPTION
This PR adds an implemation to the `AnnotationNormalizer` to change the object's retrieved property value to a more human-readable value during normalization.

Example annotation:
``` php
/**
 * @var bool
 *
 * @Export(
 *     valueMap={
 *         true = "Yes",
 *         false = "No"
 *     }
 * )
 */
```