### PR TITLE
Exporter encoding - Add an encoding option to the Exporter class

### DIFF
--- a/Export/Exporter.php
+++ b/Export/Exporter.php
@@ -47,7 +47,7 @@ class Exporter
      * @param object      $object         The object to be exported
      * @param string|null $objectName     The name of the object used in the export (eg. the root node in XML)
      * @param string      $format         The format an object is serialized to
-     * @param string|null $targetEncoding The target encoding for the XML export
+     * @param string|null $targetEncoding The target encoding for the export (XML)
      *
      * @return string
      *

--- a/Export/Exporter.php
+++ b/Export/Exporter.php
@@ -44,16 +44,17 @@ class Exporter
     /**
      * Returns a serialized/exported version of the specified object.
      *
-     * @param object      $object     The object to be exported
-     * @param string|null $objectName The name of the object used in the export (eg. the root node in XML)
-     * @param string      $format     The format an object is serialized to
+     * @param object      $object         The object to be exported
+     * @param string|null $objectName     The name of the object used in the export (eg. the root node in XML)
+     * @param string      $format         The format an object is serialized to
+     * @param string|null $targetEncoding The target encoding for the XML export
      *
      * @return string
      *
      * @throws InvalidArgumentException
      * @throws ReflectionException
      */
-    public function exportObject(/*object */$object, $objectName = null, $format = 'xml')
+    public function exportObject(/*object */$object, $objectName = null, $format = 'xml', $targetEncoding = null)
     {
         if (is_object($object) === false) {
             throw new InvalidArgumentException(
@@ -64,6 +65,9 @@ class Exporter
         $context = array(
             'xml_root_node_name' => $objectName,
         );
+        if ($targetEncoding !== null) {
+            $context['xml_encoding'] = $targetEncoding;
+        }
 
         if (is_string($context['xml_root_node_name']) === false) {
             $context['xml_root_node_name'] = (new ReflectionClass($object))->getShortName();

--- a/Export/Exporter.php
+++ b/Export/Exporter.php
@@ -64,10 +64,8 @@ class Exporter
 
         $context = array(
             'xml_root_node_name' => $objectName,
+            'xml_encoding' => $targetEncoding
         );
-        if ($targetEncoding !== null) {
-            $context['xml_encoding'] = $targetEncoding;
-        }
 
         if (is_string($context['xml_root_node_name']) === false) {
             $context['xml_root_node_name'] = (new ReflectionClass($object))->getShortName();

--- a/Export/Exporter.php
+++ b/Export/Exporter.php
@@ -47,14 +47,14 @@ class Exporter
      * @param object      $object         The object to be exported
      * @param string|null $objectName     The name of the object used in the export (eg. the root node in XML)
      * @param string      $format         The format an object is serialized to
-     * @param string|null $targetEncoding The target encoding for the export (XML)
+     * @param string      $targetEncoding The target encoding for the export (UTF-8 by default)
      *
      * @return string
      *
      * @throws InvalidArgumentException
      * @throws ReflectionException
      */
-    public function exportObject(/*object */$object, $objectName = null, $format = 'xml', $targetEncoding = null)
+    public function exportObject(/*object */$object, $objectName = null, $format = 'xml', $targetEncoding = 'UTF-8')
     {
         if (is_object($object) === false) {
             throw new InvalidArgumentException(

--- a/Resources/doc/exporter.md
+++ b/Resources/doc/exporter.md
@@ -36,7 +36,7 @@ You can export objects by using the exporter service:
 ```php
 <?php
 
-$this->get('superbrave_gdpr.exporter')->exportObject($object, $objectName, $format);
+$this->get('superbrave_gdpr.exporter')->exportObject($object, $objectName, $format, $targetEncoding);
 ```
 
 ## Examples

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -114,6 +114,34 @@ class ExporterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if Exporter::exportObject calls the serializer instance with the custom target encoding as context
+     * and returns the result of the serializer.
+     *
+     * @return void
+     */
+    public function testExportObjectWithTargetEncoding()
+    {
+        $annotatedMock = new AnnotatedMock();
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with(
+                $annotatedMock,
+                'xml',
+                array(
+                    'xml_root_node_name' => 'AnnotatedMock',
+                    'xml_encoding' => 'UTF-8'
+                )
+            )
+            ->willReturn('<?xml version="1.0" encoding="UTF-8"?><AnnotatedMock/>');
+
+        $this->assertSame(
+            '<?xml version="1.0" encoding="UTF-8"?><AnnotatedMock/>',
+            $this->exporter->exportObject($annotatedMock, null, 'xml', 'UTF-8')
+        );
+    }
+
+    /**
      * Tests if Exporter::exportObject throws an InvalidArgumentException when the first argument is not an object.
      *
      * @return void

--- a/Tests/Export/ExporterTest.php
+++ b/Tests/Export/ExporterTest.php
@@ -78,12 +78,15 @@ class ExporterTest extends PHPUnit_Framework_TestCase
             ->with(
                 $annotatedMock,
                 'xml',
-                array('xml_root_node_name' => 'AnnotatedMock')
+                array(
+                    'xml_root_node_name' => 'AnnotatedMock',
+                    'xml_encoding' => 'UTF-8'
+                )
             )
-            ->willReturn('<?xml version="1.0"?><AnnotatedMock/>');
+            ->willReturn('<?xml version="1.0" encoding="UTF-8"?><AnnotatedMock/>');
 
         $this->assertSame(
-            '<?xml version="1.0"?><AnnotatedMock/>',
+            '<?xml version="1.0" encoding="UTF-8"?><AnnotatedMock/>',
             $this->exporter->exportObject($annotatedMock)
         );
     }
@@ -103,12 +106,15 @@ class ExporterTest extends PHPUnit_Framework_TestCase
             ->with(
                 $annotatedMock,
                 'xml',
-                array('xml_root_node_name' => 'custom_name')
+                array(
+                    'xml_root_node_name' => 'custom_name',
+                    'xml_encoding' => 'UTF-8'
+                )
             )
-            ->willReturn('<?xml version="1.0"?><custom_name/>');
+            ->willReturn('<?xml version="1.0" encoding="UTF-8"?><custom_name/>');
 
         $this->assertSame(
-            '<?xml version="1.0"?><custom_name/>',
+            '<?xml version="1.0" encoding="UTF-8"?><custom_name/>',
             $this->exporter->exportObject($annotatedMock, 'custom_name')
         );
     }
@@ -119,7 +125,7 @@ class ExporterTest extends PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testExportObjectWithTargetEncoding()
+    public function testExportObjectWithCustomTargetEncoding()
     {
         $annotatedMock = new AnnotatedMock();
 
@@ -130,14 +136,14 @@ class ExporterTest extends PHPUnit_Framework_TestCase
                 'xml',
                 array(
                     'xml_root_node_name' => 'AnnotatedMock',
-                    'xml_encoding' => 'UTF-8'
+                    'xml_encoding' => 'ISO-8859-1'
                 )
             )
-            ->willReturn('<?xml version="1.0" encoding="UTF-8"?><AnnotatedMock/>');
+            ->willReturn('<?xml version="1.0" encoding="ISO-8859-1"?><AnnotatedMock/>');
 
         $this->assertSame(
-            '<?xml version="1.0" encoding="UTF-8"?><AnnotatedMock/>',
-            $this->exporter->exportObject($annotatedMock, null, 'xml', 'UTF-8')
+            '<?xml version="1.0" encoding="ISO-8859-1"?><AnnotatedMock/>',
+            $this->exporter->exportObject($annotatedMock, null, 'xml', 'ISO-8859-1')
         );
     }
 


### PR DESCRIPTION
This pull request adds a target encoding options to the exportObject() function in the Exporter class, which allows the caller to determine the encoding type of the resulting export. This is useful when exporting data with a known encoding type e.g. from a database.