### PR TITLE
Fix license typo 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
     "anonymizing",
     "exporting"
   ],
-  "licence": "MIT License",
+  "licence": [
+    "MIT"
+  ],
   "require": {
     "php": ">=7.2.0",
     "doctrine/annotations": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,8 @@
     "anonymizing",
     "exporting"
   ],
-  "licence": [
-    "MIT"
-  ],
+  "homepage": "https://www.superbrave.nl",
+  "license": "MIT",
   "require": {
     "php": ">=7.2.0",
     "doctrine/annotations": "^1.4",


### PR DESCRIPTION
Composer was complaining about: `Property 'licence' is not allowed`